### PR TITLE
Fixed include file name for case-sensitive file systems

### DIFF
--- a/src/Fuzzy_32_Channel_Servo_Board.h
+++ b/src/Fuzzy_32_Channel_Servo_Board.h
@@ -9,7 +9,7 @@
 #define _Fuzzy_32_Channel_Servo_Board_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
Fixed a minor typo that prevents the library from working on Linux and others using case-sensitive file systems.